### PR TITLE
betaln can handle much bigger numbers by using Math.Lgamma

### DIFF
--- a/ebisu.go
+++ b/ebisu.go
@@ -227,8 +227,12 @@ func logsumexp(a, b [2]float64) float64 {
 	return math.Log(sum) + aMax
 }
 
-// mathBeta returns natural logarithm of the Beta function.
+// betaln returns natural logarithm of the Beta function.
 func betaln(a, b float64) float64 {
 	// B(x,y) = Γ(x)Γ(y) / Γ(x+y)
-	return math.Log(math.Gamma(a) * math.Gamma(b) / math.Gamma(a+b))
+	// Therefore log(B(x,y)) = log(Γ(x)) + log(Γ(y)) - log(Γ(x+y))
+	la, _ := math.Lgamma(a)
+	lb, _ := math.Lgamma(b)
+	lab, _ := math.Lgamma(a + b)
+	return la + lb - lab
 }

--- a/ebisu_test.go
+++ b/ebisu_test.go
@@ -103,6 +103,8 @@ func TestBetaln(t *testing.T) {
 	assert.InDelta(t, -28.23, betaln(13, 35), 0.01)
 	assert.InDelta(t, -84.94, betaln(47.25, 80.5), 0.01)
 	assert.InDelta(t, -59.9, betaln(79.75, 26.25), 0.01)
+	assert.InDelta(t, -137.26, betaln(999, 30.25), 0.01)
+	assert.InDelta(t, -224.85, betaln(99, 300.25), 0.01)
 }
 
 func toHourDuration(hours float64) time.Duration {


### PR DESCRIPTION
Since B(x,y) = Γ(x)Γ(y) / Γ(x+y), we can take the log of both sides and get

log(B(x,y)) = log(Γ(x)) + log(Γ(y)) - log(Γ(x+y)).

Go gives us a nice [`Lgamma`](https://golang.org/pkg/math/#Lgamma) function to do `log(Γ(x))`, which can handle much bigger arguments than `Gamma` (note `Gamma(172.0)` overflows float64). If we use this, `betaln` can handle a much wider range of numbers, and may also be more accurate for the range it can currently handle. We also can skip a call to `Math.log`.

I also updated tests for this, and obtained expected values from Scipy:
```py
In [1]: from scipy.special import betaln

In [2]: betaln(999, 30.25)
Out[2]: -137.26364471946727

In [3]: betaln(99, 300.25)
Out[3]: -224.85049134021347
```